### PR TITLE
feat: adjust viewport

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,3 @@
+.md-grid {
+  max-width: 900px; 
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,4 +30,5 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
-
+extra_css:
+  - stylesheets/extra.css


### PR DESCRIPTION
The viewport is too big, it toggles to mobile view so shrinking this. Whatever makes the top horizontal menu stay, does this make sense @marcoceppi ?