### PR TITLE
fix: Installation link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,7 +60,7 @@ extra:
 nav: 
   - Home: index.md
   - Installation: 
-    - Installation: installation.md
+    - installation.md
     - Images: images.md
     - Toolboxes: toolboxes.md
   - Community:


### PR DESCRIPTION
This makes it so if you click on "Installation" it'll load installation.md instead of having it as a sub-menu item