### PR TITLE
docs: move rpm-ostree to the bottom

### DIFF
--- a/docs/guide/software.md
+++ b/docs/guide/software.md
@@ -1,24 +1,5 @@
 # Installing Software
 
-## `rpm-ostree`
-
-`rpm-ostree` is the system package manager for immutable Fedora variants. Unlike on more traditional Linux desktops, on an immutable Linux distribution you probably shouldn't install everything directly onto your base system. The more liberally you use the system package manager, the more likely you are to run into some instability that affects your base operating system.
-
-To install a single package (for example, `zsh`), run
-```
-sudo rpm-ostree install zsh
-```
-
-To install multiple packages (for example, various CLI text editors), run
-```
-sudo rpm-ostree install micro neovim helix
-```
-
-To apply the staged new staged image that includes your packages, reboot your computer. 
-
-There is no search functionality in `rpm-ostree`, but you can use a general package search website such as [pkgs.org](https://pkgs.org/) or [Repology](https://repology.org/).
-There is also no command to enable [copr](https://copr.fedorainfracloud.org/) or other repositories in `rpm-ostree`, but you can add the repo files manually to `/etc/yum.repos.d/`
-
 ## Flatpak
 
 Flatpak is the default way of installing GUI applications on immutable Fedora variants. [Flathub](https://flathub.org/) is the largest repository of Flatpak applications. On Fedora versions below 38, you might need to add the Flathub repository by running
@@ -40,7 +21,7 @@ There should be a `.desktop` file for the application, so you can run it with yo
 flatpak run io.mpv.Mpv
 ```
 
-## Toolbox
+## Distrobox and Toolbox
 
 Toolboxes are little CLI podman containers that you can install anything into without it polluting your host system. Read more on [the dedicated page](/guide/toolbox).
 
@@ -56,3 +37,22 @@ fleek add -a micro
 The `-a` flag will apply the changes immediately, omitting it will just edit your configuration file and wait until you run `fleek apply` to apply it.
 
 Read [the Fleek docs](https://getfleek.dev/) for more information.
+
+## `rpm-ostree`
+
+`rpm-ostree` is the system package manager for immutable Fedora variants. Unlike on more traditional Linux desktops, on an immutable Linux distribution you probably shouldn't install everything directly onto your base system. The more liberally you use the system package manager, the more likely you are to run into some instability that affects your base operating system, therefore we recommend that you use it sparingly.
+
+To install a single package (for example, `zsh`), run
+```
+sudo rpm-ostree install zsh
+```
+
+To install multiple packages (for example, various CLI text editors), run
+```
+sudo rpm-ostree install micro neovim helix
+```
+
+To apply the staged new staged image that includes your packages, reboot your computer. 
+
+There is no search functionality in `rpm-ostree`, but you can use a general package search website such as [pkgs.org](https://pkgs.org/) or [Repology](https://repology.org/).
+There is also no command to enable [copr](https://copr.fedorainfracloud.org/) or other repositories in `rpm-ostree`, but you can add the repo files manually to `/etc/yum.repos.d/`


### PR DESCRIPTION
We want flatpak and toolbox to be options ahead of rpm-ostree