### PR TITLE
feat: customize colorscheme to match "brand"

### DIFF
--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -26,3 +26,14 @@
   --md-footer-bg-color: #1e2335;
   --md-footer-bg-color--dark: #1b1f2c;
 }
+
+.md-typeset .admonition.abstract,
+.md-typeset details.abstract {
+  border-color: var(--md-accent-fg-color) !important;
+}
+
+.md-typeset .abstract > .admonition-title,
+.md-typeset .abstract > summary {
+  background-color: transparent !important;
+  border-bottom: 1px solid var(--md-accent-fg-color) !important;
+}

--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -1,3 +1,9 @@
+/*
+This file sets custom colors for the Material theme based on the uBlue logos and materials.
+docs on changing colors: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/
+color variable names: https://github.com/squidfunk/mkdocs-material/blob/master/src/assets/stylesheets/main/_colors.scss
+*/
+
 /* light mode */
 :root,
 [data-md-color-scheme="default"] {
@@ -27,11 +33,11 @@
   --md-footer-bg-color--dark: #1b1f2c;
 }
 
+/* Change the hardcoded colors in the image list cards */
 .md-typeset .admonition.abstract,
 .md-typeset details.abstract {
   border-color: var(--md-accent-fg-color) !important;
 }
-
 .md-typeset .abstract > .admonition-title,
 .md-typeset .abstract > summary {
   background-color: transparent !important;

--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -1,0 +1,28 @@
+/* light mode */
+:root,
+[data-md-color-scheme="default"] {
+  --md-primary-bg-color: #aac9f6;
+  --md-primary-fg-color: #1d2555;
+
+  --md-accent-fg-color: #5163db !important;
+  --md-accent-fg-color--dark: #2e3a8b !important;
+  --md-typeset-a-color: var(--md-accent-fg-color--dark) !important;
+
+  --md-footer-bg-color: #1e2335;
+  --md-footer-bg-color--dark: #1b1f2c;
+}
+
+/* dark mode */
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #aac9f6;
+  --md-default-fg-color--light: #aac9f6;
+
+  --md-primary-bg-color: #1d2555;
+  --md-default-bg-color: #22283f !important;
+
+  --md-accent-fg-color--light: #909df0 !important;
+  --md-typeset-a-color: var(--md-accent-fg-color--light) !important;
+
+  --md-footer-bg-color: #1e2335;
+  --md-footer-bg-color--dark: #1b1f2c;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,12 +10,16 @@ theme:
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-auto
         name: Switch to light mode
 
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
+      primary: custom
+      accent: custom
       scheme: default
       toggle:
         icon: material/brightness-7
@@ -23,6 +27,8 @@ theme:
 
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
+      primary: custom
+      accent: custom
       scheme: slate
       toggle:
         icon: material/brightness-4
@@ -41,6 +47,8 @@ theme:
     - search.share
     - toc.integrate
     - content.tabs.link
+extra_css:
+  - stylesheets/colors.css
 markdown_extensions:
   - admonition
   - attr_list


### PR DESCRIPTION
I dislike the default Material colors so I tried changing them to match the materials I've made for uBlue.

<details>
<summary>Screenshots</summary>

![image](https://github.com/ublue-os/website/assets/60004820/74713ece-65a0-4d69-a462-b5b28cc7287e)

![image](https://github.com/ublue-os/website/assets/60004820/b4c585c8-0e63-4cf5-b558-e969d81b5d6d)

Change to the image list cards shown on the live website (injected css) (the colors were hardcoded originally)
![image](https://github.com/ublue-os/website/assets/60004820/042db245-0cd1-4399-8fd6-0af9cab4e3c8)
</details>

I honestly don't know if I like these changes, but I'll see what yall think of them. I could (as the only designed-type person here) just decide to change us over to [rosé pine](https://rosepinetheme.com/) or smth and redo everything with it's colors but that wouldn't be very blue. 