### PR TITLE
fix: move search plugin from mkdocs.insiders.yml to mkdocs.yml

### DIFF
--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -1,5 +1,4 @@
 INHERIT: mkdocs.yml
 plugins:
   - blog
-  - search
   - social

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ extra:
     - icon: fontawesome/solid/rss
       link: https://ublue.it/feed_rss_updated.xml
 plugins:
+  - search
   - external-markdown
   - mkdocs-video:
       video_muted: True


### PR DESCRIPTION
Allows easier testing from contributors who don't have mkdocs-material-insiders