### PR TITLE
feat: add silverblue-experimental to blocklist

### DIFF
--- a/.github/ublue-scan.yml
+++ b/.github/ublue-scan.yml
@@ -11,6 +11,7 @@ ignores:
 - kinoite
 - nvidia
 - silverblue
+- silverblue-experimental
 - startingpoint
 - ubuntu
 - udev-rules


### PR DESCRIPTION
We don't want things from the experimental repo listed on the page