### PR TITLE
fix: move gh cli app below webui

### DIFF
--- a/docs/tinker/setup/manual.md
+++ b/docs/tinker/setup/manual.md
@@ -53,16 +53,17 @@ This part is important, as users must have a method of verifying the image. The 
     - Do NOT put in a password when it asks you to, just press enter. The signing key will be used in GitHub Actions and will not work if it is encrypted.
   
 3. Add the private key to GitHub
-    - If you have the `github-cli` installed, run:
-  
-    ```bash
-    gh secret set SIGNING_SECRET < cosign.key`
-    ```
 
     - This can also be done manually. Go to your repository settings, under Secrets and Variables -> Actions
     ![image](https://user-images.githubusercontent.com/1264109/216735595-0ecf1b66-b9ee-439e-87d7-c8cc43c2110a.png)
     Add a new secret and name it `SIGNING_SECRET`, then paste the contents of `cosign.key` into the secret and save it. Make sure it's the .key file and not the .pub file. Once done, it should look like this:  
     ![image](https://user-images.githubusercontent.com/1264109/216735690-2d19271f-cee2-45ac-a039-23e6a4c16b34.png)
+
+    - (CLI instructions) If you have the `github-cli` installed, run:
+  
+    ```bash
+    gh secret set SIGNING_SECRET < cosign.key
+    ```
   
 4. Commit the `cosign.pub` file into your git repository
 


### PR DESCRIPTION
This tool isn't provided by default, people should default to the webui