### PR TITLE
fix: misc startingpoint heads-up blog fixes

### DIFF
--- a/docs/blog/posts/startingpoint-rewrite-heads-up.md
+++ b/docs/blog/posts/startingpoint-rewrite-heads-up.md
@@ -19,14 +19,14 @@ Unfortunately, breaking changes have been made to the configuration (recipe) and
 For maintainers of custom images, there are a couple of ways to deal with this.
 
 - Create a new repository and port your changes
-        - This approach will be easiest if you are not that familiar with `git` and your changes are small.
-        - This approach has the advantage that you can keep using your old repository while porting all of your changes to the new one.
-        - If your old repository is a fork of startingpoint, you might want to [detach](https://support.github.com/contact?tags=rr-forks&subject=Detach%20Fork&flow=detach_fork) it from startingpoint. This would allow you to fork startingpoint again to create your new repository (GitHub allows only one fork per-repo per-account).
+    - This approach will be easiest if you are not that familiar with `git` and your changes are small.
+    - This approach has the advantage that you can keep using your old repository while porting all of your changes to the new one.
+    - If your old repository is a fork of startingpoint, you might want to [detach](https://support.github.com/contact?tags=rr-forks&subject=Detach%20Fork&flow=detach_fork) it from startingpoint. This would allow you to fork startingpoint again to create your new repository (GitHub allows only one fork per-repo per-account).
 - Do a manual merge of the rewrite into your repository
-        - You'll need to be familiar with using some software that allows you to do manual git merges. You want to accept all incoming files that are not configuration files, and manually figure out the configuration files.
-        - This approach has the advantage of keeping your git history, and allowing you to easily move all your custom scripts into the new build at once.
+    - You'll need to be familiar with using some software that allows you to do manual git merges. You want to accept all incoming files that are not configuration files, and manually figure out the configuration files.
+    - This approach has the advantage of keeping your git history, and allowing you to easily move all your custom scripts into the new build at once.
 - Do nothing
-        - Perhaps you've got a great custom build system going, you've done a lot of changes to `build.sh`, you've added new features you need. Or you just can't be bothered? Cool! You don't need to keep up-to-date with the startingpoint template if you don't want to. You'll still get OS updates, your current setup won't break. You just won't be able to take advantage of new features that might get added to startingpoint.
+    - Perhaps you've got a great custom build system going, you've done a lot of changes to `build.sh`, you've added new features you need. Or you just can't be bothered? Cool! You don't need to keep up-to-date with the startingpoint template if you don't want to. You'll still get OS updates, your current setup won't break. You just won't be able to take advantage of new features that might get added to startingpoint.
 
 ## Ok, but what actually changed?
 

--- a/docs/blog/posts/startingpoint-rewrite-heads-up.md
+++ b/docs/blog/posts/startingpoint-rewrite-heads-up.md
@@ -17,15 +17,16 @@ The rewrite brings startingpoint from a single `build.sh` where incrementally ad
 
 Unfortunately, breaking changes have been made to the configuration (recipe) and the script system.   
 For maintainers of custom images, there are a couple of ways to deal with this.
+
 - Create a new repository and port your changes
-    - This approach will be easiest if you are not that familiar with `git` and your changes are small.
-    - This approach has the advantage that you can keep using your old repository while porting all of your changes to the new one.
-    - If your old repository is a fork of startingpoint, you might want to [detach](https://support.github.com/contact?tags=rr-forks&subject=Detach%20Fork&flow=detach_fork) it from startingpoint. This would allow you to fork startingpoint again to create your new repository (GitHub allows only one fork per-repo per-account).
+        - This approach will be easiest if you are not that familiar with `git` and your changes are small.
+        - This approach has the advantage that you can keep using your old repository while porting all of your changes to the new one.
+        - If your old repository is a fork of startingpoint, you might want to [detach](https://support.github.com/contact?tags=rr-forks&subject=Detach%20Fork&flow=detach_fork) it from startingpoint. This would allow you to fork startingpoint again to create your new repository (GitHub allows only one fork per-repo per-account).
 - Do a manual merge of the rewrite into your repository
-    - You'll need to be familiar with using some software that allows you to do manual git merges. You want to accept all incoming files that are not configuration files, and manually figure out the configuration files.
-    - This approach has the advantage of keeping your git history, and allowing you to easily move all your custom scripts into the new build at once.
+        - You'll need to be familiar with using some software that allows you to do manual git merges. You want to accept all incoming files that are not configuration files, and manually figure out the configuration files.
+        - This approach has the advantage of keeping your git history, and allowing you to easily move all your custom scripts into the new build at once.
 - Do nothing
-    - Perhaps you've got a great custom build system going, you've done a lot of changes to `build.sh`, you've added new features you need. Or you just can't be bothered? Cool! You don't need to keep up-to-date with the startingpoint template if you don't want to. You'll still get OS updates, your current setup won't break. You just won't be able to take advantage of new features that might get added to startingpoint.
+        - Perhaps you've got a great custom build system going, you've done a lot of changes to `build.sh`, you've added new features you need. Or you just can't be bothered? Cool! You don't need to keep up-to-date with the startingpoint template if you don't want to. You'll still get OS updates, your current setup won't break. You just won't be able to take advantage of new features that might get added to startingpoint.
 
 ## Ok, but what actually changed?
 

--- a/docs/blog/posts/startingpoint-rewrite-heads-up.md
+++ b/docs/blog/posts/startingpoint-rewrite-heads-up.md
@@ -87,7 +87,7 @@ As a minor change, all user configuration has been moved into the `config/` dire
 
 When it is fully ready, tested, and documentation changes have been PRd onto the documentation website. A while after the merge there'll be a more newcomer-friendly announcement post. The new version will be considered a '1.0', and the amount of breaking changes will be kept as zero for as long as possible. 
 
-To quicken or effect the process, feel free to give comments and read through [the PR](https://github.com/ublue-os/startingpoint/pull/135)
+To quicken or effect the process, feel free to give comments, read through, and help in testing [the PR](https://github.com/ublue-os/startingpoint/pull/135).
    
 For post-release I have plans for a PR that would allow the configuration of _multiple_ modules be included using the `from-file:` syntax, a PR that would allow an entire directory full of build scripts to be run at once, without having to specify each one individually, and a blog post that would showcase high-level technical details of the repository without needing to get in the weeds by reading source code.
 


### PR DESCRIPTION
* List indentation
* Better PR review call to action

Remaining minor bug that is another mkdocs peculiarity:
* The `#` symbols at the top level of the included `yml` block are doubled 