### PR TITLE
fix: use strict build to catch invalid nav links

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
       run: mkdocs build -f mkdocs.insiders.yml
     - name: Build MkDocs
       if: ${{ github.ref_name != 'main' }}
-      run: mkdocs build
+      run: mkdocs build --strict
     - name: Upload site artifact
       uses: actions/upload-pages-artifact@v1
       with:


### PR DESCRIPTION
To catch invalid links in the navigation section of the website, we could use the `--strict` flag which should turn warning into errors. This should catch something like this:
https://github.com/ublue-os/website/actions/runs/6164187895/job/16729371704#step:10:32

More info here:
https://www.mkdocs.org/user-guide/configuration/#validation