### PR TITLE
feat: add storage requirement

### DIFF
--- a/docs/images/bazzite/installation.md
+++ b/docs/images/bazzite/installation.md
@@ -14,6 +14,7 @@ Installation tutorial begins at [1:37](https://youtu.be/aaeRk8_i1Ds?feature=shar
 
 * Make sure you meet the [system requirements](https://docs.fedoraproject.org/en-US/fedora/latest/release-notes/welcome/Hardware_Overview/) for Fedora.
 * A graphics card that can utilize Vulkan 1.3 or later, but most modern AMD, Nvidia, and Intel GPUs should be fine.
+* The drive that Bazzite is installed to must have at least 20GB unallocated drive space.
 * A USB flash drive, external drive, or microSD card with at least 3GB of free space on it. **(Keep in mind this will remove existing data on it!)**
 * A working, stable, wired or wireless internet connection.
 * Download an ISO release [here.](https://github.com/ublue-os/bazzite/releases)


### PR DESCRIPTION
I have seen at least 1 Youtube comment asking how much storage is needed for Bazzite.  

In my own testing, a 16GB drive would NOT get past the Bazzite Portal first-boot setup phase, but a 32GB VM installation was fine.  I compromised with 20GB as a hard minimum system requirement.