### PR TITLE
fix: use git-commits plugin only on deployment

### DIFF
--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -2,3 +2,7 @@ INHERIT: mkdocs.yml
 plugins:
   blog: {}
   social: {}
+  git-committers:
+    enabled: true
+    repository: ublue-os/website
+    branch: main

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,10 +83,6 @@ plugins:
       css_style:
         width: "50%"
         height: "22.172vw"
-  git-committers:
-      enabled: true
-      repository: ublue-os/website
-      branch: main
   rss:
       match_path: blog/posts/.*
       date_from_meta:


### PR DESCRIPTION
We error out in strict mode when fetching git-commiters when a file not exists on a PR. To avoid this we only use this plugin when we actually deploy the website.