### PR TITLE
fix: FAQ to include Bazzite's Discussions...

### DIFF
--- a/docs/images/bazzite/FAQ.md
+++ b/docs/images/bazzite/FAQ.md
@@ -113,5 +113,4 @@ Running Steam in Distrobox has the advantage of using [LatencyFleX](https://gith
 There is a [minor performance impact](https://github.com/flatpak/flatpak/issues/4187) if you run/attempt to run Flatpak games. However it is only noticeable with certain edge cases.
 
 ##  I am experiencing a bug or want to request a feature, but I'm not sure where to report it.
-
-Explain your issue or proposal in our [issue tracker](https://github.com/ublue-os/bazzite/issues) or [Github Discussions Page](https://github.com/orgs/ublue-os/discussions).
+Explain your issue or proposal in our [issue tracker](https://github.com/ublue-os/bazzite/issues) or [Github Discussions Page](https://github.com/ublue-os/bazzite/discussions).


### PR DESCRIPTION
...Not the general Universal Blue one.  Do not want questions specifically for Bazzite to end up being asked on the main images.