### PR TITLE
fix: missed typo in bluefin-dx page

### DIFF
--- a/docs/images/bluefin/developer-experience.md
+++ b/docs/images/bluefin/developer-experience.md
@@ -20,7 +20,7 @@ Like all Universal Blue images, switching is atomic, allowing for clean switchin
 
 ### Visual Studio Code
 
-[Visual Studio Code](https://code.visualstudio.com/) is included on the image to facilitate local development. It comes configured for usage with [devcontainers] and Podman via a small [default configuration file](https://github.com/ublue-os/bluefin/blob/main/dx/usr/etc/skel.d/.config/Code/User/settings.json).
+[Visual Studio Code](https://code.visualstudio.com/) is included on the image to facilitate local development. It comes configured for usage with devcontainers and Podman via a small [default configuration file](https://github.com/ublue-os/bluefin/blob/main/dx/usr/etc/skel.d/.config/Code/User/settings.json).
 
 - [Dev Containers Documentation](https://code.visualstudio.com/docs/devcontainers/containers) - you can skip most of the installation instructions and go directly to [the tutorial](https://code.visualstudio.com/docs/devcontainers/tutorial#_install-the-extension)
 - [Dev Containers Specification](https://containers.dev/) 


### PR DESCRIPTION
I'm not sure if there was an intention to link to a certain place or not. But the link is not there, so I removed the brackets. If the intention was to link to a page, please add in via review.