### PR TITLE
chore(ci): disable cancel-in-progress

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 */12 * * *'
   pull_request:
+  push:
+    branches:
+    - main
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
This maybe the cause of the deployment being canceled when a PR is being merged into the main branch.

`Canceling since a higher priority waiting request for 'pages' exists`

Also bring back the on push branch main
```
  push:
    branches:
    - main
```

Not 100% sure, but worth a shot.