### PR TITLE
fix: change related link title to bluefin

### DIFF
--- a/docs/blog/posts/bluefin-one-point-oh-rc.md
+++ b/docs/blog/posts/bluefin-one-point-oh-rc.md
@@ -6,7 +6,7 @@ authors:
 categories:
   - bluefin
 links:
-  - Bazzite: https://github.com/ublue-os/bluefin
+  - Bluefin: https://github.com/ublue-os/bluefin
   
 ---
 

--- a/docs/blog/posts/bluefin-one-point-oh-rc.md
+++ b/docs/blog/posts/bluefin-one-point-oh-rc.md
@@ -12,7 +12,7 @@ links:
 
 # Bluefin is on its way to Beta
 
-After nearly two(!) years of prototyping and testing, [Bluefin](/images/bluefin) is on it's way to Beta! We're hoping to do the final release of the beta on November 1st, so we'd like to spend a some time testing the ISO. 
+After nearly two(!) years of prototyping and testing, [Bluefin](/images/bluefin) is on its way to Beta! We're hoping to do the final release of the beta on November 1st, so we'd like to spend a some time testing the ISO. 
 
 Bluefin is an interpretation of the Ubuntu spirit built with Fedora technology. It's a familiar(ish) Ubuntu desktop for Fedora Silverblue. It strives to cover these three use cases:
 


### PR DESCRIPTION
The related link on the `bluefin-one-point-oh-rc.md` blogpost was titled bazzite instead of bluefin.