### PR TITLE
Update some nvidia-related commands and links.

### DIFF
--- a/docs/guide/codecs.md
+++ b/docs/guide/codecs.md
@@ -12,14 +12,18 @@ For Nvidia graphics cards, there is no official support for VA-API. However, the
 
 Regardless of your graphics hardware, uBlue includes the packages you need to enable Hardware-accelerated codecs using VA-API.
 
-## How to check that hardware-accelerated codecs are working
+## How to check that hardware-accelerated codecs are properly detected
 
-To check if hardware-accelerated codecs are working, you can use Firefox:
+To check if hardware-accelerated codecs are being recognized by your system, you can use Firefox:
 
 1. Open Firefox.
 2. In the address bar, type `about:support` and press Enter.
 3. Look for the section titled "Media"
-4. If hardware-accelerated codecs are working you should see `HW` listed next to some codecs. For example ![firefox-with-hw-codecs](https://user-images.githubusercontent.com/815081/229374952-a345de0c-fb2a-4f22-9de3-1c0a7184d1d0.png)
+4. If hardware-accelerated codecs are detected you should see `HW` listed next to some codecs. For example ![firefox-with-hw-codecs](https://user-images.githubusercontent.com/815081/229374952-a345de0c-fb2a-4f22-9de3-1c0a7184d1d0.png)
+
+## (nvidia) How to check that hardware-accelerated codecs are in use
+
+While playing or encoding a video, open a terminal and run `nvidia-smi dmon`. If the GPU codec is in use, there will be a positive value under the "dec" (decoder) or enc (encoder) columns. For troubleshooting, check the [nvidia page](/images/nvidia/).
 
 ## How to configure the Firefox flatpak to use hardware-accelerated codecs
 
@@ -31,6 +35,8 @@ The Firefox flatpak may require a small configuration change to enable hardware-
 4. Search for `media.ffmpeg.vaapi.enable`.
 5. Set the value to **true**.
 6. Restart firefox to apply the change.
+
+Nvidia users will need to follow [additional steps](/images/nvidia/#video-playback).
 
 ## How to Install the `ffmpeg-full` Flatpak Runtime
 

--- a/docs/guide/just.md
+++ b/docs/guide/just.md
@@ -10,15 +10,15 @@ Typing `just` in the command line will show possible commands and descriptions. 
 
 - `just bios` - boot into UEFI/bios. Useful for multiple boot systems
 - `just changelogs` - show a changelog between the running system and the latest updates
-- `just clean` - clean up old containers and packaging metadata
+- `just clean-system` - clean up old containers and packaging metadata
 - `just distrobox-<name-of-distro>` - E.g. `just distrobox-fedora` - pre-made distroboxes of common distributions
 - `just update` - update all packages, flatpaks, and distroboxes
 
 ### Nvidia Images
 
-- `just set-kargs-nvidia` - set boot arguments to blacklist nouveau
-- `just test-cuda` - test CUDA
-- `just setup-firefox-flatpak-vaapi-nvidia` - set the flatpak override to get VAAPI working
+- `just nvidia-set-kargs` - set boot arguments to blacklist nouveau
+- `just nvidia-test-cuda` - test CUDA
+- `just nvidia-setup-firefox-vaapi` - set the flatpak override to get VAAPI working
 - `just enroll-secure-boot-key` - import boot key used to sign all [uBlue built kernel modules](https://github.com/ublue-os/akmods)
 
 Commands are updated and maintained by the community, feel free to [submit a command](https://github.com/ublue-os/config/tree/main/build/ublue-os-just) if you feel it is something that would be useful for all users.
@@ -43,7 +43,7 @@ Commands are updated and maintained by the community, feel free to [submit a com
 - `10-update.just` is a `justfile` available in all `main` and derived images.  It is specifically designed around updating your image and updates your system packages, installed flatpak applications, and containers all at once.
 - `20-clean.just` is a `justfile` available in all `main` and derived images.  It is designed around cleaning your system.  Cleans up containers, unused flatpak dependencies, optimises Nix if installed, and cleans up older system deployments.
 - `30-distrobox.just` is a `justfile` available in all `main` and derived images.  It is centered around creating Distrobox containers with ease.
-- `40-nvidia.just` is a `justfile` available in all `nvidia` and derived images. It includes Nvidia-specific recipes such as `just set-kargs-nvidia`.
+- `40-nvidia.just` is a `justfile` available in all `nvidia` and derived images. It includes Nvidia-specific recipes such as `just nvidia-set-kargs`.
 - `50-akmods.just` is a `justfile` available in `nvidia` and derived images.  It may also be in some speciality images too.  It is a layer to add extra kernel modules to the image and is mainly used for better hardware support.
 - `60-custom.just` is a `justfile` available in `startingpoint` and derived images. It is intended to have recipes provided by the custom image maintainer.
 

--- a/docs/images/nvidia.md
+++ b/docs/images/nvidia.md
@@ -13,12 +13,12 @@ These images are based on the experimental `ostree` native container images host
 
 - Multiple Nvidia driver streams (535xx and 470xx)
 - CUDA support
-- [Container runtime support](https://github.com/ublue-os/nvidia#using-nvidia-gpus-in-containers)
+- [Container runtime support](#using-nvidia-gpus-in-containers)
 - Secure boot
-- [Hardware-accelerated video playback](https://github.com/ublue-os/nvidia#video-playback)
+- [Hardware-accelerated video playback](#video-playback)
 - Selinux support
-- [Multiple Fedora flavors and releases](https://github.com/ublue-os/nvidia#setup)
-- Post-install setup with [`just`](https://github.com/ublue-os/config/blob/main/build/ublue-os-just/nvidia.just)
+- [Multiple Fedora flavors and releases](#setup)
+- Post-install setup with [`just`](https://github.com/ublue-os/config/blob/main/build/ublue-os-just/40-nvidia.just)
 - Multi-GPU support with [`supergfxctl`](https://gitlab.com/asus-linux/supergfxctl) ([optional Gnome Shell extension](https://extensions.gnome.org/extension/5344/supergfxctl-gex/))
 
 ## Setup
@@ -166,6 +166,7 @@ podman run \
     --security-opt=no-new-privileges \
     --cap-drop=ALL \
     --security-opt label=type:nvidia_container_t  \
+    --device=nvidia.com/gpu=all \
     docker.io/nvidia/samples:vectoradd-cuda11.2.1
 ```
 
@@ -177,7 +178,13 @@ Additional runtime packages are added for enabling hardware-accelerated video pl
 - `media.ffmpeg.vaapi.enabled`
 - `widget.dmabuf.force-enabled`
 
-Extensive host access and reduced sand-boxing is needed for Firefox flatpak to use `/usr/lib64/dri/nvidia_drv_video.so`:
+RPM users will need to run Firefox with the following environment variables to use `/usr/lib64/dri/nvidia_drv_video.so`:
+
+```
+env LIBVA_DRIVER_NAME=nvidia MOZ_DISABLE_RDD_SANDBOX=1 NVD_BACKEND=direct firefox
+```
+
+Flatpak users will also need to provide more extensive host access and reduced sand-boxing:
 
 ```bash
 flatpak override \
@@ -191,6 +198,8 @@ flatpak override \
     --env=MOZ_ENABLE_WAYLAND=1 \
     org.mozilla.firefox
 ```
+
+You can verify whether the GPU is being used for video decoding by running `nvidia-smi dmon` while the video is playing.
 
 ## Acknowledgements
 


### PR DESCRIPTION
- Fixed a few outdated links.
- Updated syntax for some example commands (`just` commands & running containers with GPU access).
- Clarified that RPM Firefox users need to set some of the same env variables as is recommended for the Flatpak versions. Otherwise, the codecs would show up in Firefox about:support (the current recommendation for checking whether it's "working"), but Firefox would still default to software decoding.