### PR TITLE
chore: update bluefin.iso link

### DIFF
--- a/docs/blog/posts/bluefin-one-point-oh-rc.md
+++ b/docs/blog/posts/bluefin-one-point-oh-rc.md
@@ -22,7 +22,7 @@ Bluefin is an interpretation of the Ubuntu spirit built with Fedora technology. 
  
 **A good internet connection is required.**
 
-## [bluefin-38-2023-10-23-x86_64.iso](https://ublue.download/bluefin-38-2023-10-23-x86_64-rc.iso)
+## [bluefin-38-2023-10-27-x86_64.iso](https://ublue.download/bluefin-38-2023-10-27-x86_64-rc.iso)
 
 ### Instructions
 


### PR DESCRIPTION
We released a newer beta iso a few days after the written blogpost. If people decide to get the iso from the link after reading the blogpost, lets point them to the latest version which has some small changes in it. 

I think it was things like `just update` changes.