### PR TITLE
Added info to codecs guide

### DIFF
--- a/docs/guide/codecs.md
+++ b/docs/guide/codecs.md
@@ -57,3 +57,11 @@ flatpak list --runtime | grep ffmpeg-full
 ```
 
 This command should return the version(s) of the runtime that you installed.
+
+To check what runtime version a certain program is currently running (i.e Firefox), enter in a terminal:
+
+```bash
+flatpak info org.mozilla.firefox | grep Runtime
+```
+
+Ensure that you also get the ffmpeg-full version returned by the previous command.


### PR DESCRIPTION
This will help people find the ffmpeg-full runtime version needed for enabling HW in a certain program.