### PR TITLE
fix: remove tlp documentation

### DIFF
--- a/docs/images/surface.md
+++ b/docs/images/surface.md
@@ -11,13 +11,12 @@ From the [linux-surface project](https://github.com/linux-surface/linux-surface)
 Like all Universal Blue images, hardware acceleration and codecs are [included out of the box](/guide/codecs) and the system strives for a zero-maintenance based approach.
 
 - Replaces the stock Fedora kernel with the [Surface kernel](https://github.com/linux-surface/linux-surface/tree/master/pkg/fedora)
-- Replaces `power-profiles-daemon` with `tlp`
+- Adds the [correct kernel modules](https://github.com/ublue-os/surface/blob/main/system_files/shared/usr/etc/modules-load.d/ublue-surface.conf) 
 
 ## How to Help
 
 Open Source succeeds best when contributors come together to solve a problem. These are areas where contributions would be appreciated:
 
-- Additional `tlp` configurations. The image is designed to allow shipping multiple power profiles; we just need to collect and curate a set that would be the most useful for people.
 - Benchmarking tools. It would be nice to be able to run a continuous benchmark that exercises the laptop and can run unattended so that we can automate power testing.
 
 We want to allow Linux users to share this knowledge and expertise with each other to fulfill the true potential of Surface devices. We'll [use science](https://www.youtube.com/watch?v=BABM3EUo990) and the wonders of modern automation to accomplish this!


### PR DESCRIPTION
Surface images no longer use this