### PR TITLE
chore: use `--pull=newer` for create-ublue-image

### DIFF
--- a/docs/tinker/setup/auto-cli.md
+++ b/docs/tinker/setup/auto-cli.md
@@ -6,7 +6,7 @@
 
 For automatic setup using the command line, there is a community-built tool called [`create-ublue-image`](https://github.com/xynydev/create-ublue-image). The tools uses `github-cli` which technically has a lot more access to your GitHub account than needed, if this is a concern to you, you can read the source code. It is packaged as a container you can run with [Podman](https://podman.io/), which is installed by default on Universal Blue images.
 
-1. Run the command `podman run -v "$(pwd)":/host --security-opt label=disable -it ghcr.io/xynydev/create-ublue-image` in a subdirectory of your home directory
+1. Run the command `podman run -v "$(pwd)":/host --security-opt label=disable --pull=newer -it ghcr.io/xynydev/create-ublue-image` in a subdirectory of your home directory
     - This will mount the current directory for modification inside the container. If you want the folder containing your repo to be in a certain directory like `~/dev`, you should `cd` into that before executing the tool.
     - If you have any issues, read [the project's](https://github.com/xynydev/create-ublue-image) README and submit to its issue tracker.
 2. Follow the instructions the tool gives you


### PR DESCRIPTION
As the create-ublue-image tool evolves, it is possible that users could end up running an older version of the tool when setting up a new custom ublue image. Supplying `--pull=newer` to the `podman run` command ensures that users should always get the latest image when the command is run.