### PR TITLE
chore: tooling migration -related changes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,11 +18,6 @@ This project provides:
     ---
     A diverse set of [continuously delivered](https://en.wikipedia.org/wiki/Continuous_delivery) Fedora-based images for people to use as their desktop operating system
 
-- :material-toolbox:{ .lg .middle } __Toolkit__
-
-    ---
-    A diverse set of tools and [a reusable automation kit](https://github.com/ublue-os/startingpoint) for more technical users so that they can customize and share their images with others
-
 - :material-speedometer:{ .lg .middle } __Experimental Applications__
 
     ---

--- a/docs/tinker.md
+++ b/docs/tinker.md
@@ -1,5 +1,5 @@
-# Universal Blue's old custom image tooling is moving
+# Universal Blue's old custom image tooling has been moved
 
-Per mutual decisision ([ublue-os/startingpoint#223](https://github.com/ublue-os/startingpoint/issues/223) & [ublue-os/main#476](https://github.com/ublue-os/main/issues/476)), the custom image build tooling based on recipes is moving to a different organization as it's own project. [BlueBuild](https://blue-build.org/) is the new place to get support and documentation. The same maintaners are continuing work on the project. 
+Per mutual decisision ([ublue-os/startingpoint#223](https://github.com/ublue-os/startingpoint/issues/223) & [ublue-os/main#476](https://github.com/ublue-os/main/issues/476)), the custom image build tooling based on recipes is moving to a different organization as it's own project. [BlueBuild](https://blue-build.org/) is the new place to get support and documentation. The same maintaners are continuing work on the project.
 
-More information regarding things such as migration is going to be published later this month. In the meantime, _don't panic_, your current custom image repository is going to keep working.
+Read the [full introductory blog post](https://blue-build.org/blog/introducing-bluebuild/) (including a migration guide) on BlueBuild's website. _Don't panic_, you can keep your existing configuration, and your current custom image repository is going to keep working with no required changes for at least a few months.


### PR DESCRIPTION
This PR should be merged right after the custom image tooling -related repositories are moved. https://github.com/ublue-os/main/issues/476

The "toolkit" card is also removed from the front page. Y'all can decide whether to add something similar back talking about something adjacent.

If someone wishes to review the referenced blog post before it is published, it can be read right here: https://github.com/blue-build/website/pull/28/files#diff-7b9d9b0968b0ff050f433578e787cacfa5f0526c908c1848ccd41d1591859207